### PR TITLE
Appimage support and a fix for Windows docker build

### DIFF
--- a/.github/workflows/linux-docker-build.yml
+++ b/.github/workflows/linux-docker-build.yml
@@ -1,3 +1,4 @@
+name: Build docker image for Linux builds
 on:
   push:
     branches:

--- a/.github/workflows/linux-docker-build.yml
+++ b/.github/workflows/linux-docker-build.yml
@@ -1,4 +1,4 @@
-name: Build docker image for Linux builds
+name: Docker for Linux builds
 on:
   push:
     branches:

--- a/.github/workflows/linux-docker-packaging-appimage.yml
+++ b/.github/workflows/linux-docker-packaging-appimage.yml
@@ -1,0 +1,39 @@
+on:
+  push:
+    branches:
+      - master
+      - main
+      - dev
+    tags:
+      - '*'
+
+env:
+  DOCKER_IMAGE_NAME: ghcr.io/noxworld-dev/docker-build
+
+jobs:
+  linux_builder:
+    name: Linux packaging: AppImage
+    runs-on: 'ubuntu-20.04'
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: true
+
+      - name: Log in to the GHCR.IO
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build the docker image
+        run: |
+          docker pull $DOCKER_IMAGE_NAME:latest-linux-packaging-appimage && $(exit 0)
+          cd ./linux-packaging-appimage
+          docker build --build-arg BUILDKIT_INLINE_CACHE=1 --cache-from $DOCKER_IMAGE_NAME:latest-linux-packaging-appimage -t $DOCKER_IMAGE_NAME:tmp-linux-packaging-appimage .
+
+      - name: Push
+        run: |
+          docker tag $DOCKER_IMAGE_NAME:tmp-linux-packaging-appimage $DOCKER_IMAGE_NAME:latest-linux-packaging-appimage
+          docker push $DOCKER_IMAGE_NAME:latest-linux-packaging-appimage

--- a/.github/workflows/linux-docker-packaging-appimage.yml
+++ b/.github/workflows/linux-docker-packaging-appimage.yml
@@ -1,3 +1,4 @@
+name: Build docker image for Appimage packaging
 on:
   push:
     branches:

--- a/.github/workflows/linux-docker-packaging-appimage.yml
+++ b/.github/workflows/linux-docker-packaging-appimage.yml
@@ -8,7 +8,7 @@ on:
       - '*'
 
 env:
-  DOCKER_IMAGE_NAME: ghcr.io/noxworld-dev/docker-build
+  DOCKER_IMAGE_NAME: ghcr.io/noxworld-dev/build-docker
 
 jobs:
   linux_builder:

--- a/.github/workflows/linux-docker-packaging-appimage.yml
+++ b/.github/workflows/linux-docker-packaging-appimage.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   linux_builder:
-    name: Linux packaging: AppImage
+    name: Linux packaging - AppImage
     runs-on: 'ubuntu-20.04'
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/linux-docker-packaging-appimage.yml
+++ b/.github/workflows/linux-docker-packaging-appimage.yml
@@ -1,4 +1,4 @@
-name: Build docker image for Appimage packaging
+name: Docker for Appimage packaging
 on:
   push:
     branches:

--- a/.github/workflows/win-docker-build.yml
+++ b/.github/workflows/win-docker-build.yml
@@ -1,4 +1,4 @@
-name: Build docker images
+name: Build docker image for Windows builds
 on:
   push:
     branches:

--- a/.github/workflows/win-docker-build.yml
+++ b/.github/workflows/win-docker-build.yml
@@ -1,4 +1,4 @@
-name: Build docker image for Windows builds
+name: Docker for Windows builds
 on:
   push:
     branches:

--- a/linux-packaging-appimage/Dockerfile
+++ b/linux-packaging-appimage/Dockerfile
@@ -1,12 +1,15 @@
 FROM --platform=linux/386 debian:bookworm-slim
 
+ENV APPIMAGETOOL_RELEASE="13"
+ENV APPIMAGETOOL_FOLDER="/usr/bin"
 # Appimage generation scripts
 COPY scripts/ /scripts/
 
 # Prerequisites for the appimagetool. Marking scripts as executable
 RUN apt update && apt upgrade -y && apt install -y zlib1g file wget &&\
-	apt install -y libsdl2-dev libopenal-dev && chmod -v a+x /scripts/*.sh
+	apt install -y libsdl2-dev libopenal-dev && chmod -v a+x /scripts/*.sh &&\
+	wget -q --show-progress  -O "$APPIMAGETOOL_FOLDER/appimagetool-$APPIMAGETOOL_RELEASE.AppImage" "https://github.com/AppImage/AppImageKit/releases/download/$APPIMAGETOOL_RELEASE/appimagetool-i686.AppImage" &&\
+	chmod +x "$APPIMAGETOOL_FOLDER/appimagetool-$APPIMAGETOOL_RELEASE.AppImage"
 
 COPY entrypoint.sh /entrypoint.sh
-# ENV APPIMAGETOOL_RELEASE="13"
 ENTRYPOINT /entrypoint.sh

--- a/linux-packaging-appimage/Dockerfile
+++ b/linux-packaging-appimage/Dockerfile
@@ -8,7 +8,7 @@ COPY scripts/ /scripts/
 # Prerequisites for the appimagetool. Marking scripts as executable
 RUN apt update && apt upgrade -y && apt install -y zlib1g file wget &&\
 	apt install -y libsdl2-dev libopenal-dev && chmod -v a+x /scripts/*.sh &&\
-	wget --show-progress  -O "$APPIMAGETOOL_FOLDER/appimagetool-$APPIMAGETOOL_RELEASE.AppImage" "https://github.com/AppImage/AppImageKit/releases/download/$APPIMAGETOOL_RELEASE/appimagetool-i686.AppImage" &&\
+	wget -q --show-progress  -O "$APPIMAGETOOL_FOLDER/appimagetool-$APPIMAGETOOL_RELEASE.AppImage" "https://github.com/AppImage/AppImageKit/releases/download/$APPIMAGETOOL_RELEASE/appimagetool-i686.AppImage" &&\
 	chmod -v +x "$APPIMAGETOOL_FOLDER/appimagetool-$APPIMAGETOOL_RELEASE.AppImage"
 
 COPY entrypoint.sh /entrypoint.sh

--- a/linux-packaging-appimage/Dockerfile
+++ b/linux-packaging-appimage/Dockerfile
@@ -8,8 +8,8 @@ COPY scripts/ /scripts/
 # Prerequisites for the appimagetool. Marking scripts as executable
 RUN apt update && apt upgrade -y && apt install -y zlib1g file wget &&\
 	apt install -y libsdl2-dev libopenal-dev && chmod -v a+x /scripts/*.sh &&\
-	wget -q --show-progress  -O "$APPIMAGETOOL_FOLDER/appimagetool-$APPIMAGETOOL_RELEASE.AppImage" "https://github.com/AppImage/AppImageKit/releases/download/$APPIMAGETOOL_RELEASE/appimagetool-i686.AppImage" &&\
-	chmod +x "$APPIMAGETOOL_FOLDER/appimagetool-$APPIMAGETOOL_RELEASE.AppImage"
+	wget --show-progress  -O "$APPIMAGETOOL_FOLDER/appimagetool-$APPIMAGETOOL_RELEASE.AppImage" "https://github.com/AppImage/AppImageKit/releases/download/$APPIMAGETOOL_RELEASE/appimagetool-i686.AppImage" &&\
+	chmod -v +x "$APPIMAGETOOL_FOLDER/appimagetool-$APPIMAGETOOL_RELEASE.AppImage"
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT /entrypoint.sh

--- a/linux-packaging-appimage/Dockerfile
+++ b/linux-packaging-appimage/Dockerfile
@@ -1,10 +1,13 @@
-FROM i386/debian:bookworm-slim
+FROM --platform=linux/386 debian:bookworm-slim
 
 # Prerequisites for the appimagetool.
 RUN apt update
-RUN apt install -y zlib1g libfuse2
+RUN apt upgrade -y
+RUN apt install -y zlib1g file wget
+RUN apt install -y libsdl2-dev libopenal-dev
 
 # Appimage generation scripts
 COPY scripts/ /scripts/
 COPY entrypoint.sh /entrypoint.sh
+# ENV PATH=/usr/sbin:$PATH
 ENTRYPOINT /entrypoint.sh

--- a/linux-packaging-appimage/Dockerfile
+++ b/linux-packaging-appimage/Dockerfile
@@ -1,11 +1,12 @@
 FROM --platform=linux/386 debian:bookworm-slim
 
-# Prerequisites for the appimagetool.
-RUN apt update && apt upgrade -y && apt install -y zlib1g file wget &&\
-	apt install -y libsdl2-dev libopenal-dev
-
 # Appimage generation scripts
 COPY scripts/ /scripts/
+
+# Prerequisites for the appimagetool. Marking scripts as executable
+RUN apt update && apt upgrade -y && apt install -y zlib1g file wget &&\
+	apt install -y libsdl2-dev libopenal-dev && chmod -v a+x /scripts/*.sh
+
 COPY entrypoint.sh /entrypoint.sh
-# ENV PATH=/usr/sbin:$PATH
+# ENV APPIMAGETOOL_RELEASE="13"
 ENTRYPOINT /entrypoint.sh

--- a/linux-packaging-appimage/Dockerfile
+++ b/linux-packaging-appimage/Dockerfile
@@ -1,0 +1,10 @@
+FROM i386/debian:bookworm-slim
+
+# Prerequisites for the appimagetool.
+RUN apt update
+RUN apt install -y zlib1g libfuse2
+
+# Appimage generation scripts
+COPY scripts/ /scripts/
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT /entrypoint.sh

--- a/linux-packaging-appimage/Dockerfile
+++ b/linux-packaging-appimage/Dockerfile
@@ -1,10 +1,8 @@
 FROM --platform=linux/386 debian:bookworm-slim
 
 # Prerequisites for the appimagetool.
-RUN apt update
-RUN apt upgrade -y
-RUN apt install -y zlib1g file wget
-RUN apt install -y libsdl2-dev libopenal-dev
+RUN apt update && apt upgrade -y && apt install -y zlib1g file wget &&\
+	apt install -y libsdl2-dev libopenal-dev
 
 # Appimage generation scripts
 COPY scripts/ /scripts/

--- a/linux-packaging-appimage/entrypoint.sh
+++ b/linux-packaging-appimage/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+chmod -v a+x /scripts/*.sh
+echo "Generating libraries list..."
+./gen_libs_list.sh
+echo "Generating AppImage..."
+./deploy.sh
+echo "Moving appimage into the build directory..."
+mv opennox-bundle-i386.AppImage "${GITHUB_WORKSPACE}/build"
+echo "Done"

--- a/linux-packaging-appimage/entrypoint.sh
+++ b/linux-packaging-appimage/entrypoint.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 set -e
-chmod -v a+x /scripts/*.sh
 echo "Generating libraries list..."
 /scripts/gen_libs_list.sh
 echo "Generating AppImage..."

--- a/linux-packaging-appimage/entrypoint.sh
+++ b/linux-packaging-appimage/entrypoint.sh
@@ -2,9 +2,9 @@
 set -e
 chmod -v a+x /scripts/*.sh
 echo "Generating libraries list..."
-./gen_libs_list.sh
+/scripts/gen_libs_list.sh
 echo "Generating AppImage..."
-./deploy.sh
+/scripts/deploy.sh
 echo "Moving appimage into the build directory..."
-mv opennox-bundle-i386.AppImage "${GITHUB_WORKSPACE}/build"
+mv ${GITHUB_WORKSPACE}/opennox-bundle-i386.AppImage "${GITHUB_WORKSPACE}/build"
 echo "Done"

--- a/linux-packaging-appimage/scripts/deploy.sh
+++ b/linux-packaging-appimage/scripts/deploy.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # OpenNox AppImage bulder by Xandros Darkstorm (Discord for support: xandrosdarkstorm)
-# Version 1.3
+# Version 1.4
 
 # Unfortunately AppImageKit project has no strict policy regarding releases.
 PROJECT_FOLDER="${GITHUB_WORKSPACE}/build"
@@ -8,6 +8,11 @@ LIBS_LIST="libs_to_copy"
 if [ -z $APPIMAGETOOL_RELEASE ]; then
 	# Use "continuous" build to get the latest development build. You can still specify any other build (13 is the latest).
 	APPIMAGETOOL_RELEASE="13"
+fi
+
+if [ -z $APPIMAGETOOL_FOLDER ]; then
+	# The path to the appimagetool. Added to allow pre-downloading during building Docker container.
+	APPIMAGETOOL_FOLDER="."
 fi
 
 if [ -z $OPENNOX_CFG ]; then
@@ -58,15 +63,15 @@ fi
 }
 
 echo "Checking appimagetool..."
-if [ ! -x "./appimagetool-$APPIMAGETOOL_RELEASE.AppImage" ] || [ "$APPIMAGETOOL_RELEASE" = "continuous" ]; then
+if [ ! -x "$APPIMAGETOOL_FOLDER/appimagetool-$APPIMAGETOOL_RELEASE.AppImage" ] || [ "$APPIMAGETOOL_RELEASE" = "continuous" ]; then
 echo "Downloading appimagetool..."
-wget -q --show-progress  -O appimagetool-$APPIMAGETOOL_RELEASE.AppImage "https://github.com/AppImage/AppImageKit/releases/download/$APPIMAGETOOL_RELEASE/appimagetool-i686.AppImage"
+wget -q --show-progress  -O "$APPIMAGETOOL_FOLDER/appimagetool-$APPIMAGETOOL_RELEASE.AppImage" "https://github.com/AppImage/AppImageKit/releases/download/$APPIMAGETOOL_RELEASE/appimagetool-i686.AppImage"
 	if [ $? -gt 0 ]; then
-	rm appimagetool-$APPIMAGETOOL_RELEASE.AppImage
+	rm "$APPIMAGETOOL_FOLDER/appimagetool-$APPIMAGETOOL_RELEASE.AppImage"
 	echo "Failed to download appimagetool. Aborting. Please check if you have an access to GitHub."
 	exit 1
 	fi
-chmod +x appimagetool-$APPIMAGETOOL_RELEASE.AppImage
+chmod +x "$APPIMAGETOOL_FOLDER/appimagetool-$APPIMAGETOOL_RELEASE.AppImage"
 fi
 
 echo "Preparing bundle structure..."
@@ -218,10 +223,10 @@ make_dummyicon_on_fail
 echo "Building the AppImage..."
 if [ -z $SIGNKEY ]; then
 echo "AppImage will not be signed."
-./appimagetool-$APPIMAGETOOL_RELEASE.AppImage --appimage-extract-and-run -n --comp gzip opennox_bundle.AppDir
+$APPIMAGETOOL_FOLDER/appimagetool-$APPIMAGETOOL_RELEASE.AppImage --appimage-extract-and-run -n --comp gzip opennox_bundle.AppDir
 else
 echo "AppImage will be signed with GPG key '$SIGNKEY'."
-./appimagetool-$APPIMAGETOOL_RELEASE.AppImage --appimage-extract-and-run -n --comp gzip -s --sign-key $SIGNKEY opennox_bundle.AppDir
+$APPIMAGETOOL_FOLDER/appimagetool-$APPIMAGETOOL_RELEASE.AppImage --appimage-extract-and-run -n --comp gzip -s --sign-key $SIGNKEY opennox_bundle.AppDir
 fi
 exit_on_build_fail
 

--- a/linux-packaging-appimage/scripts/deploy.sh
+++ b/linux-packaging-appimage/scripts/deploy.sh
@@ -1,0 +1,226 @@
+#!/bin/sh
+# OpenNox AppImage bulder by Xandros Darkstorm (Discord for support: xandrosdarkstorm)
+# Version 1.1
+
+# Unfortunately AppImageKit project has no strict policy regarding releases.
+# Use "continuous" build to get the latest development build. You can still specify any other build (13 is the latest).
+APPIMAGETOOL_RELEASE="13"
+PROJECT_FOLDER="${GITHUB_WORKSPACE}/build"
+LIBS_LIST="libs_to_copy"
+
+if [ -z $OPENNOX_CFG ]; then
+	OPENNOX_CFG="opennox/opennox.yml"
+fi
+if [ -z $OPENNOX_DATA ]; then
+	OPENNOX_DATA="opennox/gamedata"
+fi
+if [ -z $OPENNOX_STATEFILES ]; then
+	OPENNOX_STATEFILES="opennox"
+fi
+#SIGNKEY="xandros-test-key"
+
+exit_on_error()
+{
+if [ $? -gt 0 ]; then
+echo "$1"
+exit 1
+fi
+}
+
+bundle_struct_exit_on_error()
+{
+exit_on_error "Failed to create bundle structure. Aborting."
+}
+
+bundle_makedir_exit_on_error()
+{
+exit_on_error "Failed to make directory '$1' for library. Aborting."
+}
+
+bundle_filecopy_exit_on_error()
+{
+exit_on_error "Failed to copy files. Aborting."
+}
+
+exit_on_build_fail()
+{
+exit_on_error "Failed to compile AppImage. Aborting."
+}
+
+make_dummyicon_on_fail()
+{
+if [ $? -gt 0 ]; then
+echo "Icon not found. Making a stub icon."
+touch opennox_bundle.AppDir/opennox.png
+fi
+}
+
+echo "Checking appimagetool..."
+if [ ! -x "./appimagetool-$APPIMAGETOOL_RELEASE.AppImage" ] || [ "$APPIMAGETOOL_RELEASE" = "continuous" ]; then
+echo "Downloading appimagetool..."
+wget -q --show-progress  -O appimagetool-$APPIMAGETOOL_RELEASE.AppImage "https://github.com/AppImage/AppImageKit/releases/download/$APPIMAGETOOL_RELEASE/appimagetool-i686.AppImage"
+	if [ $? -gt 0 ]; then
+	rm appimagetool-$APPIMAGETOOL_RELEASE.AppImage
+	echo "Failed to download appimagetool. Aborting. Please check if you have an access to GitHub."
+	exit 1
+	fi
+chmod +x appimagetool-$APPIMAGETOOL_RELEASE.AppImage
+fi
+
+echo "Preparing bundle structure..."
+rm -rf opennox_bundle.AppDir
+mkdir -p opennox_bundle.AppDir/usr/bin
+bundle_struct_exit_on_error
+
+echo "Copying project files..."
+cp $PROJECT_FOLDER/opennox opennox_bundle.AppDir/usr/bin/opennox
+bundle_filecopy_exit_on_error
+cp $PROJECT_FOLDER/opennox-hd opennox_bundle.AppDir/usr/bin/opennox-hd
+bundle_filecopy_exit_on_error
+cp $PROJECT_FOLDER/opennox-server opennox_bundle.AppDir/usr/bin/opennox-server
+bundle_filecopy_exit_on_error
+
+echo "Copying libraries:"
+while read lib_to_copy
+do
+	echo "Copying $lib_to_copy..."
+	libdir="opennox_bundle.AppDir$(dirname "$lib_to_copy")"
+	if [ ! -d $libdir ]; then
+		mkdir -p $libdir
+		bundle_makedir_exit_on_error "$libdir"
+	fi
+	cp -v $lib_to_copy $libdir
+	if [ $? -gt 0 ]; then
+		bundle_filecopy_exit_on_error
+	fi
+done < $LIBS_LIST
+echo "Libraries have been copied successfully."
+
+echo "Generating runner script..."
+cat > opennox_bundle.AppDir/AppRun <<EOF
+#!/bin/sh
+if [ -z \$APPDIR ]; then
+	APPDIR=\$PWD
+fi
+
+if [ -z \$PATH ]; then
+	OLDPATH=""
+else
+	OLDPATH=":"\$PATH
+fi
+PATH="\$APPDIR/usr/local/bin:\$APPDIR/usr/bin:\$APPDIR/bin:\$APPDIR/usr/local/games:\$APPDIR/usr/games"\$OLDPATH
+
+if [ -z \$LD_LIBRARY_PATH ]; then
+	OLDLIBSPATH=""
+else
+	OLDLIBSPATH=":"\$LD_LIBRARY_PATH
+fi
+LD_LIBRARY_PATH="\$APPDIR/usr/lib:\$APPDIR/usr/lib/i386-linux-gnu/:\$APPDIR/usr/lib/i386-linux-gnu/pulseaudio/:\$APPDIR/usr/lib32/:\$APPDIR/lib/:\$APPDIR/lib/i386-linux-gnu/:\$APPDIR/lib32/"\$OLDLIBSPATH
+
+XDG_DATA_DIRS="/usr/local/share/:/usr/share/\$XDG_DATA_DIRS"
+
+if [ -z \$XDG_CONFIG_HOME ]; then
+	cfgpath="\$HOME/.config/$OPENNOX_CFG"
+else
+	cfgpath="\$XDG_CONFIG_HOME/$OPENNOX_CFG"
+fi
+
+if [ -z \$XDG_DATA_HOME ]; then
+	datapath="\$HOME/.local/share/$OPENNOX_DATA"
+else
+	datapath="\$XDG_DATA_HOME/$OPENNOX_DATA"
+fi
+
+if [ -z \$XDG_STATE_HOME ]; then
+	statepath="\$HOME/.local/state/$OPENNOX_STATEFILES"
+else
+	statepath="\$XDG_DATA_HOME/$OPENNOX_STATEFILES"
+fi
+
+exit_on_mkdir_error()
+{
+if [ \$? -gt 0 ]; then
+echo "Unable to create path '\$1'. Check if you have sufficient permissions or try using portable home mode (--appimage-portable-home as first parameter)."
+exit 1
+fi
+}
+
+mkdir -p \$(dirname \$cfgpath)
+exit_on_mkdir_error "\$(dirname \$cfgpath)"
+mkdir -p "\$statepath"
+exit_on_mkdir_error "\$statepath"
+if [ ! -d \$datapath ]; then
+mkdir -p "\$datapath"
+exit_on_mkdir_error "\$datapath"
+echo "Please put Nox game files here and restart the AppImage: \$datapath"
+exit 2
+fi
+
+cd \$statepath
+
+export APPDIR
+export APPIMAGE
+export ARGV0
+export OWD
+export PATH
+export LD_LIBRARY_PATH
+
+if [ "\$1" = "help" ]; then
+	echo "OpenNox Appimage-specific parameters:"
+	echo "\$ARGV0 hd [other parameters]"
+	echo "    Run OpenNox HD."
+	echo "\$ARGV0 server [other parameters]"
+	echo "    Run OpenNox dedicated server."
+	echo " "
+	echo "OpenNox Appimage edition changes the path to files to conform to the XDG Base Directory Specification v0.8."
+	echo "Your config file must be here: \$cfgpath"
+	echo "Your game files must be here: \$datapath"
+	echo "OpenNox log files will be stored here: \$statepath"
+	echo " "
+	echo "Please note, that Appimage can work in completely portable fashion: just run the AppImage like this:"
+	echo "\$ARGV0 server --appimage-portable-home"
+	echo "This will create folder that will serve as a portable space for the OpenNox. Then run OpenNox as usual."
+	exit 0
+elif [ "\$1" = "hd" ]; then
+	shift 1
+	opennox-hd --config=\$cfgpath --data=\$datapath "\$@"
+elif [ "\$1" = "server" ]; then
+	shift 1
+	opennox-server --config=\$cfgpath --data=\$datapath "\$@"
+else
+	if [ ! -z "\$1" ]; then
+		shift 1
+	fi
+	opennox --config=\$cfgpath --data=\$datapath "\$@"
+fi
+EOF
+chmod +x opennox_bundle.AppDir/AppRun
+
+echo "Generating necessary junk for AppImage builder..."
+cat > opennox_bundle.AppDir/opennox-bundle.desktop <<EOF 
+[Desktop Entry]
+Name=opennox-bundle
+Terminal=true
+Exec=echo "Tweak this .desktop file to run AppRun."
+Icon=opennox
+Type=Application
+Categories=Game
+EOF
+chmod +x opennox_bundle.AppDir/opennox-bundle.desktop
+cp $PROJECT_FOLDER/opennox.png opennox_bundle.AppDir 2>/dev/null
+make_dummyicon_on_fail
+
+echo "Building the AppImage..."
+if [ -z $SIGNKEY ]; then
+echo "AppImage will not be signed."
+./appimagetool-$APPIMAGETOOL_RELEASE.AppImage -n --comp gzip opennox_bundle.AppDir
+else
+echo "AppImage will be signed with GPG key '$SIGNKEY'."
+./appimagetool-$APPIMAGETOOL_RELEASE.AppImage -n --comp gzip -s --sign-key $SIGNKEY opennox_bundle.AppDir
+fi
+exit_on_build_fail
+
+echo "Cleaning up..."
+rm -rf opennox_bundle.AppDir
+
+echo "Script work is done."

--- a/linux-packaging-appimage/scripts/deploy.sh
+++ b/linux-packaging-appimage/scripts/deploy.sh
@@ -1,12 +1,14 @@
 #!/bin/sh
 # OpenNox AppImage bulder by Xandros Darkstorm (Discord for support: xandrosdarkstorm)
-# Version 1.2
+# Version 1.3
 
 # Unfortunately AppImageKit project has no strict policy regarding releases.
-# Use "continuous" build to get the latest development build. You can still specify any other build (13 is the latest).
-APPIMAGETOOL_RELEASE="13"
 PROJECT_FOLDER="${GITHUB_WORKSPACE}/build"
 LIBS_LIST="libs_to_copy"
+if [ -z $APPIMAGETOOL_RELEASE ]; then
+	# Use "continuous" build to get the latest development build. You can still specify any other build (13 is the latest).
+	APPIMAGETOOL_RELEASE="13"
+fi
 
 if [ -z $OPENNOX_CFG ]; then
 	OPENNOX_CFG="opennox/opennox.yml"

--- a/linux-packaging-appimage/scripts/deploy.sh
+++ b/linux-packaging-appimage/scripts/deploy.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # OpenNox AppImage bulder by Xandros Darkstorm (Discord for support: xandrosdarkstorm)
-# Version 1.1
+# Version 1.2
 
 # Unfortunately AppImageKit project has no strict policy regarding releases.
 # Use "continuous" build to get the latest development build. You can still specify any other build (13 is the latest).
@@ -75,10 +75,13 @@ bundle_struct_exit_on_error
 echo "Copying project files..."
 cp $PROJECT_FOLDER/opennox opennox_bundle.AppDir/usr/bin/opennox
 bundle_filecopy_exit_on_error
+chmod +x opennox_bundle.AppDir/usr/bin/opennox
 cp $PROJECT_FOLDER/opennox-hd opennox_bundle.AppDir/usr/bin/opennox-hd
 bundle_filecopy_exit_on_error
+chmod +x opennox_bundle.AppDir/usr/bin/opennox-hd
 cp $PROJECT_FOLDER/opennox-server opennox_bundle.AppDir/usr/bin/opennox-server
 bundle_filecopy_exit_on_error
+chmod +x opennox_bundle.AppDir/usr/bin/opennox-server
 
 echo "Copying libraries:"
 while read lib_to_copy
@@ -213,10 +216,10 @@ make_dummyicon_on_fail
 echo "Building the AppImage..."
 if [ -z $SIGNKEY ]; then
 echo "AppImage will not be signed."
-./appimagetool-$APPIMAGETOOL_RELEASE.AppImage -n --comp gzip opennox_bundle.AppDir
+./appimagetool-$APPIMAGETOOL_RELEASE.AppImage --appimage-extract-and-run -n --comp gzip opennox_bundle.AppDir
 else
 echo "AppImage will be signed with GPG key '$SIGNKEY'."
-./appimagetool-$APPIMAGETOOL_RELEASE.AppImage -n --comp gzip -s --sign-key $SIGNKEY opennox_bundle.AppDir
+./appimagetool-$APPIMAGETOOL_RELEASE.AppImage --appimage-extract-and-run -n --comp gzip -s --sign-key $SIGNKEY opennox_bundle.AppDir
 fi
 exit_on_build_fail
 

--- a/linux-packaging-appimage/scripts/gen_libs_list.sh
+++ b/linux-packaging-appimage/scripts/gen_libs_list.sh
@@ -1,0 +1,111 @@
+#!/bin/sh
+TMPFOLDER="/tmp/opennox-deploy-tmp"
+LIBS_LIST_OUTPUT="libs_to_copy"
+
+rm -rf $TMPFOLDER
+> $LIBS_LIST_OUTPUT
+mkdir $TMPFOLDER
+if [ $? -gt 0 ]; then
+echo "Failed to create a folder for temporary operations. Aborting."
+exit 1
+fi
+touch $TMPFOLDER/libs_to_check
+
+# [LIBS_TO_INCLUDE] List of libraries, which opennox uses.
+cat > $TMPFOLDER/libs_to_include <<EOF
+/lib/i386-linux-gnu/libSDL2-2.0.so.0
+/lib/i386-linux-gnu/libopenal.so.1
+EOF
+
+# [LIBS_TO_IGNORE] List of libraries which must be excluded from the list.
+# libc, libm and libpthread are part of libc6 package, which must never be distributed.
+# libGL must never be distributed, because it is an important system dependant graphical library.
+# libGLdispatch, libGLX are provided by libgl1 package and also vendor-dependant
+cat > $TMPFOLDER/ignoredlibs <<EOF
+libc.so
+libm.so
+libpthread.so
+libGL.so
+libGLX.so
+libGLdispatch.so
+EOF
+
+is_lib_missing=0
+is_library_ignored()
+{
+	ignored=0
+	while read ignoredlib
+	do
+		if [ ! "${1##"$ignoredlib"*}" ]; then
+			ignored=1
+			break
+		fi
+	done < $TMPFOLDER/ignoredlibs
+	return $ignored
+}
+
+is_library_already_checked()
+{
+	checked=0
+	while read checkedlib
+	do
+		if [ "$1" = "$checkedlib" ]; then
+			checked=1
+			break
+		fi
+	done < $TMPFOLDER/libs_to_check
+	return $checked
+}
+
+get_lib_dependecies()
+{
+	# We need only libraries.
+	ldd "$1" | grep "=>" > $TMPFOLDER/lddout
+	while read currentlib
+	do
+		libname=$(echo "$currentlib" | cut -d " " -f1)
+		libpath=$(echo "$currentlib" | cut -d " " -f3)
+		is_library_already_checked $libpath
+		if [ $? -eq 0 ]; then
+			if [ -f $libpath ]; then
+				is_library_ignored $libname
+				if [ $? -eq 0 ]; then
+					echo "$libpath" >> $LIBS_LIST_OUTPUT
+					echo "$libpath" >> $TMPFOLDER/libs_to_check
+				fi
+			else
+				echo "Library is missing: $libname ($libpath)"
+				is_lib_missing=1
+			fi
+		fi
+	done < $TMPFOLDER/lddout
+}
+
+while read currentlib
+do
+	# Check if lib exists. If it is -- include it into list and retrieve its dependencies.
+	if [ -f $currentlib ];then
+		is_library_ignored ${currentlib##*/}
+		if [ $? -eq 1 ]; then
+			echo "Error: library $currentlib is not allowed for inclusion."
+			rm -rf $TMPFOLDER
+			exit 1
+		else
+			echo "$currentlib" >> $LIBS_LIST_OUTPUT
+			# Retrieve dependencies
+			get_lib_dependecies "$currentlib"
+		fi
+	else
+		echo "Library not found: $lib"
+		is_lib_missing=1
+	fi
+done < $TMPFOLDER/libs_to_include
+if [ $is_lib_missing -eq 1 ]; then
+	rm $LIBS_LIST_OUTPUT
+	echo "Please install these libraries and run this script again"
+	exit 1
+else
+	echo "Script work is done. List of libraries has been saved in '$LIBS_LIST_OUTPUT' file"
+fi
+rm -rf $TMPFOLDER
+exit 0

--- a/windows-build/Dockerfile
+++ b/windows-build/Dockerfile
@@ -3,13 +3,15 @@ FROM archlinux/archlinux:base-devel
 ENV MAKEFLAGS -j8
 ENV CGO_ENABLED 1
 
-RUN pacman -Syu --noconfirm &&\
-	pacman -S --noconfirm git go multilib-devel &&\
-	useradd -m builder &&\
-	git clone --depth 1 -b go-cgo-gcc-parallelism-1.20.3 https://github.com/Evengard/go &&\
-	cd go/src && ./make.bash && pacman -R --noconfirm go &&\
-	echo "builder ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/builder &&\
-	su builder -c "cd &&\
+RUN echo -e "[multilib]\nInclude = /etc/pacman.d/mirrorlist" >> /etc/pacman.conf
+RUN pacman -Syu --noconfirm
+RUN pacman -S --noconfirm git go multilib-devel
+RUN	useradd -m builder
+RUN	git clone --depth 1 -b go-cgo-gcc-parallelism-1.20.3 https://github.com/Evengard/go &&\
+	cd go/src && ./make.bash
+RUN pacman -R --noconfirm go
+RUN	echo "builder ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/builder	
+RUN sudo -u builder sh -c "cd &&\
 		git clone https://aur.archlinux.org/yay-bin.git &&\
 		cd yay-bin &&\
 		makepkg -si --noconfirm &&\

--- a/windows-build/Dockerfile
+++ b/windows-build/Dockerfile
@@ -3,15 +3,13 @@ FROM archlinux/archlinux:base-devel
 ENV MAKEFLAGS -j8
 ENV CGO_ENABLED 1
 
-RUN echo -e "[multilib]\nInclude = /etc/pacman.d/mirrorlist" >> /etc/pacman.conf
-RUN pacman -Syu --noconfirm
-RUN pacman -S --noconfirm git go multilib-devel
-RUN	useradd -m builder
-RUN	git clone --depth 1 -b go-cgo-gcc-parallelism-1.20.3 https://github.com/Evengard/go &&\
-	cd go/src && ./make.bash
-RUN pacman -R --noconfirm go
-RUN	echo "builder ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/builder	
-RUN sudo -u builder sh -c "cd &&\
+RUN echo -e "[multilib]\nInclude = /etc/pacman.d/mirrorlist" >> /etc/pacman.conf &&\
+	pacman -Syu --noconfirm && pacman -S --noconfirm git go multilib-devel &&\
+	useradd -m builder &&\
+	git clone --depth 1 -b go-cgo-gcc-parallelism-1.20.3 https://github.com/Evengard/go &&\
+	cd go/src && ./make.bash && pacman -R --noconfirm go &&\
+	echo "builder ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/builder	&&\
+	sudo -u builder sh -c "cd &&\
 		git clone https://aur.archlinux.org/yay-bin.git &&\
 		cd yay-bin &&\
 		makepkg -si --noconfirm &&\


### PR DESCRIPTION
### PR explanation
This PR provides the following changes:
-  Dockerfile and scripts required to build an AppImage.
- Fix to a bug with Docker for Windows builds, which was breaking compilation completely.
- Added names to Github Action jobs.

### ⚠️ Important notice
**Appimage does not work on Ubuntu since version 22, since it doesn't ship libfuse2 anymore.** AppImageTool developers are working on the problem and should soon release an update that will solve this problem. As soon as they do it, i will release an update to the AppImage packaging scripts.

### AppImage build differences
AppImage build has several key differences to the normal OpenNox build:
1. Because AppImage packs all 3 executable releases in one package i had to make some tweaks to the way how user runs this AppImage. It reads first arguments and checks for a predefined keyword. If keyword is found - an action is performed and rest of the arguments will be applied to the executable without including this keyword (if applicable).
- **"hd"** - run OpenNox HD edition (_opennox-hd_)
- **"server"** - run OpenNox dedicated server (_opennox-server_)
- **"help"** - provides help about this list of keywords and other important information about the AppImage release.
- If nothing is specified or the first argument is not any of these keywords, then normal OpenNox will be run (_opennox_).
2. AppImage container itself provides some command line arguments you can use. Just open the AppImage with "--appimage-help" parameter to find out what are they.
3. I did my best to adapt the container for several usual usage patterns. It is done by using "--config" and "--data" arguments provided by OpenNox itself, so **these parameters are no longer usable by user** (unless the bug is already fixed, in which case this warning should be ignored)
- The AppImage **is not portable by default** -- it stores data in pre-defined location in user's home and expects data to be there. That is done specifically to allow making packages out of this AppImage and to allow direct system installation (in /usr/local/bin for example). All locations follow Freedesktop standard "XDG Base Directory Specification v0.8" (released 8th May 2021):
    - **Game files** are expected to be in ~/.local/share/opennox directory.
    - **Game configuration** is expected to be in ~/.config/opennox directory.
    - **Game logs** will be put in ~/.local/state/opennox directory.
These directory locations cannot be changed by user -- they are hardcoded.
- If user wants AppImage to be portable, they can run it with "**--appimage-portable-home**" as the first and only argument. This will create a folder with name of the AppImage and ".home" added at the end (for example, "opennox-bundle-i386.AppImage.home"), which will act as an override and will be used by AppImage next time you run it normally. The folder can be created manually, if desired. This behavior is provided by the AppImage container, not AppRun i made for this project.

 
This is my first PR ever, i hope i did it right.