### PR TITLE
Add an option to change go toolkit version for windows builder image

### DIFF
--- a/.github/workflows/win-docker-build.yml
+++ b/.github/workflows/win-docker-build.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           docker pull $DOCKER_IMAGE_NAME:$LATEST_IMAGE_TAG && $(exit 0)
           cd ./windows-build
-          docker build --build-arg BUILDKIT_INLINE_CACHE=1 --cache-from $DOCKER_IMAGE_NAME:latest-win -t $DOCKER_IMAGE_NAME:tmp-win .
+          docker build --ulimit nofile=1024:524288 --build-arg BUILDKIT_INLINE_CACHE=1 --cache-from $DOCKER_IMAGE_NAME:latest-win -t $DOCKER_IMAGE_NAME:tmp-win .
       
       - name: Push the ${{ env.LATEST_IMAGE_TAG }} image
         run: |
@@ -66,7 +66,7 @@ jobs:
         run: |
           docker pull $DOCKER_IMAGE_NAME:$DOWNGRADE_IMAGE_TAG && $(exit 0)
           cd ./windows-build
-          docker build --build-arg GO_VERSION=go1.21.4 --build-arg BUILDKIT_INLINE_CACHE=1 --cache-from $DOCKER_IMAGE_NAME:$DOWNGRADE_IMAGE_TAG -t $DOCKER_IMAGE_NAME:tmp-win .
+          docker build --ulimit nofile=1024:524288 --build-arg GO_VERSION=go1.21.4 --build-arg BUILDKIT_INLINE_CACHE=1 --cache-from $DOCKER_IMAGE_NAME:$DOWNGRADE_IMAGE_TAG -t $DOCKER_IMAGE_NAME:tmp-win .
 
       - name: Push the ${{ env.DOWNGRADE_IMAGE_TAG }} image
         run: |

--- a/.github/workflows/win-docker-build.yml
+++ b/.github/workflows/win-docker-build.yml
@@ -19,8 +19,8 @@ env:
   DOWNGRADE_IMAGE_TAG: win-go1.21.4
 
 jobs:
-  windows_builder:
-    name: Build the MinGW docker image
+  windows_builder_latest:
+    name: Build the ${{ env.LATEST_IMAGE_TAG }} MinGW docker image
     runs-on: 'ubuntu-20.04'
     steps:
       - uses: actions/checkout@v2
@@ -45,8 +45,23 @@ jobs:
         run: |
           docker tag $DOCKER_IMAGE_NAME:tmp-win $DOCKER_IMAGE_NAME:$LATEST_IMAGE_TAG
           docker push $DOCKER_IMAGE_NAME:$LATEST_IMAGE_TAG
-          docker image rm $DOCKER_IMAGE_NAME:tmp-win
 
+  windows_builder_downgrade:
+    name: Build the ${{ env.DOWNGRADE_IMAGE_TAG }} MinGW docker image
+    runs-on: 'ubuntu-20.04'
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: true
+
+      - name: Log in to the GHCR.IO
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
       - name: Build the ${{ env.DOWNGRADE_IMAGE_TAG }} image
         run: |
           docker pull $DOCKER_IMAGE_NAME:$DOWNGRADE_IMAGE_TAG && $(exit 0)
@@ -57,5 +72,4 @@ jobs:
         run: |
           docker tag $DOCKER_IMAGE_NAME:tmp-win $DOCKER_IMAGE_NAME:$DOWNGRADE_IMAGE_TAG
           docker push $DOCKER_IMAGE_NAME:$DOWNGRADE_IMAGE_TAG
-          docker image rm $DOCKER_IMAGE_NAME:tmp-win
 

--- a/.github/workflows/win-docker-build.yml
+++ b/.github/workflows/win-docker-build.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   windows_builder_latest:
     name: Build the MinGW docker image with latest toolkit
-    runs-on: 'ubuntu-20.04'
+    runs-on: 'ubuntu-22.04'
     steps:
       - uses: actions/checkout@v2
         with:
@@ -48,7 +48,7 @@ jobs:
 
   windows_builder_downgrade:
     name: Build the MinGW docker image with downgraded toolkit
-    runs-on: 'ubuntu-20.04'
+    runs-on: 'ubuntu-22.04'
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/win-docker-build.yml
+++ b/.github/workflows/win-docker-build.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   windows_builder_latest:
-    name: Build the ${{ env.LATEST_IMAGE_TAG }} MinGW docker image
+    name: Build the MinGW docker image with latest toolkit
     runs-on: 'ubuntu-20.04'
     steps:
       - uses: actions/checkout@v2
@@ -47,7 +47,7 @@ jobs:
           docker push $DOCKER_IMAGE_NAME:$LATEST_IMAGE_TAG
 
   windows_builder_downgrade:
-    name: Build the ${{ env.DOWNGRADE_IMAGE_TAG }} MinGW docker image
+    name: Build the MinGW docker image with downgraded toolkit
     runs-on: 'ubuntu-20.04'
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/win-docker-build.yml
+++ b/.github/workflows/win-docker-build.yml
@@ -15,7 +15,9 @@ on:
 
 env:
   DOCKER_IMAGE_NAME: ghcr.io/noxworld-dev/docker-build
-  
+  LATEST_IMAGE_TAG: latest-win
+  DOWNGRADE_IMAGE_TAG: win-go1.21.4
+
 jobs:
   windows_builder:
     name: Build the MinGW docker image
@@ -33,13 +35,27 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       
-      - name: Build the docker image
+      - name: Build the ${{ env.LATEST_IMAGE_TAG }} image
         run: |
-          docker pull $DOCKER_IMAGE_NAME:latest-win && $(exit 0)
+          docker pull $DOCKER_IMAGE_NAME:$LATEST_IMAGE_TAG && $(exit 0)
           cd ./windows-build
           docker build --build-arg BUILDKIT_INLINE_CACHE=1 --cache-from $DOCKER_IMAGE_NAME:latest-win -t $DOCKER_IMAGE_NAME:tmp-win .
       
-      - name: Push
+      - name: Push the ${{ env.LATEST_IMAGE_TAG }} image
         run: |
-          docker tag $DOCKER_IMAGE_NAME:tmp-win $DOCKER_IMAGE_NAME:latest-win
-          docker push $DOCKER_IMAGE_NAME:latest-win
+          docker tag $DOCKER_IMAGE_NAME:tmp-win $DOCKER_IMAGE_NAME:$LATEST_IMAGE_TAG
+          docker push $DOCKER_IMAGE_NAME:$LATEST_IMAGE_TAG
+          docker image rm $DOCKER_IMAGE_NAME:tmp-win
+
+      - name: Build the ${{ env.DOWNGRADE_IMAGE_TAG }} image
+        run: |
+          docker pull $DOCKER_IMAGE_NAME:$DOWNGRADE_IMAGE_TAG && $(exit 0)
+          cd ./windows-build
+          docker build --build-arg GO_VERSION=go1.21.4 --build-arg BUILDKIT_INLINE_CACHE=1 --cache-from $DOCKER_IMAGE_NAME:$DOWNGRADE_IMAGE_TAG -t $DOCKER_IMAGE_NAME:tmp-win .
+
+      - name: Push the ${{ env.DOWNGRADE_IMAGE_TAG }} image
+        run: |
+          docker tag $DOCKER_IMAGE_NAME:tmp-win $DOCKER_IMAGE_NAME:$DOWNGRADE_IMAGE_TAG
+          docker push $DOCKER_IMAGE_NAME:$DOWNGRADE_IMAGE_TAG
+          docker image rm $DOCKER_IMAGE_NAME:tmp-win
+

--- a/windows-build/Dockerfile
+++ b/windows-build/Dockerfile
@@ -1,20 +1,22 @@
-FROM archlinux/archlinux:base-devel
+FROM archlinux/archlinux:multilib-devel
 
 ARG GO_VERSION="go1.21.5"
 ENV MAKEFLAGS -j8
 ENV CGO_ENABLED 1
 
-RUN echo -e "[multilib]\nInclude = /etc/pacman.d/mirrorlist" >> /etc/pacman.conf &&\
-	pacman -Syu --noconfirm && pacman -S --noconfirm git go multilib-devel &&\
+COPY entrypoint.sh /entrypoint.sh
+
+RUN pacman -Syu --noconfirm && pacman -S --noconfirm git go multilib-devel &&\
 	useradd -m builder &&\
 	git clone --depth 1 -b ${GO_VERSION} https://github.com/golang/go &&\
 	cd go/src && ./make.bash && pacman -R --noconfirm go &&\
-	echo "builder ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/builder	&&\
-	sudo -u builder sh -c "cd &&\
-		git clone https://aur.archlinux.org/yay-bin.git &&\
-		cd yay-bin &&\
-		makepkg -si --noconfirm &&\
-		yay -S --noconfirm mingw-w64-glew mingw-w64-ldd mingw-w64-openal mingw-w64-sdl2"
+	echo "builder ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/builder
+USER builder
+RUN	cd &&\
+	git clone https://aur.archlinux.org/yay-bin.git &&\
+	cd yay-bin &&\
+	makepkg -si --noconfirm &&\
+	yay -S --noconfirm mingw-w64-glew mingw-w64-ldd mingw-w64-openal mingw-w64-sdl2
 
 ENV PATH=/go/bin:$PATH
 ENV PKG_CONFIG_PATH /usr/i686-w64-mingw32/lib/pkgconfig/
@@ -23,5 +25,4 @@ ENV CGO_CFLAGS_ALLOW (-fshort-wchar)|(-fno-strict-aliasing)|(-fno-strict-overflo
 #ENV C_INCLUDE_PATH /usr/i686-w64-mingw32/include
 ENV GOARCH 386
 
-COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT /entrypoint.sh

--- a/windows-build/Dockerfile
+++ b/windows-build/Dockerfile
@@ -10,13 +10,12 @@ RUN pacman -Syu --noconfirm && pacman -S --noconfirm git go multilib-devel &&\
 	useradd -m builder &&\
 	git clone --depth 1 -b ${GO_VERSION} https://github.com/golang/go &&\
 	cd go/src && ./make.bash && pacman -R --noconfirm go &&\
-	echo "builder ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/builder
-USER builder
-RUN	cd &&\
-	git clone https://aur.archlinux.org/yay-bin.git &&\
-	cd yay-bin &&\
-	makepkg -si --noconfirm &&\
-	yay -S --noconfirm mingw-w64-glew mingw-w64-ldd mingw-w64-openal mingw-w64-sdl2
+	echo "builder ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/builder &&\
+	sudo -u builder sh -c "cd &&\
+		git clone https://aur.archlinux.org/yay-bin.git &&\
+		cd yay-bin &&\
+		makepkg -si --noconfirm &&\
+		yay -S --noconfirm mingw-w64-glew mingw-w64-ldd mingw-w64-openal mingw-w64-sdl2"
 
 ENV PATH=/go/bin:$PATH
 ENV PKG_CONFIG_PATH /usr/i686-w64-mingw32/lib/pkgconfig/

--- a/windows-build/Dockerfile
+++ b/windows-build/Dockerfile
@@ -1,12 +1,13 @@
 FROM archlinux/archlinux:base-devel
 
+ARG GO_VERSION="go1.21.5"
 ENV MAKEFLAGS -j8
 ENV CGO_ENABLED 1
 
 RUN echo -e "[multilib]\nInclude = /etc/pacman.d/mirrorlist" >> /etc/pacman.conf &&\
 	pacman -Syu --noconfirm && pacman -S --noconfirm git go multilib-devel &&\
 	useradd -m builder &&\
-	git clone --depth 1 -b go1.21.5 https://github.com/golang/go &&\
+	git clone --depth 1 -b ${GO_VERSION} https://github.com/golang/go &&\
 	cd go/src && ./make.bash && pacman -R --noconfirm go &&\
 	echo "builder ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/builder	&&\
 	sudo -u builder sh -c "cd &&\


### PR DESCRIPTION
Add an option to change go toolkit version for windows builder image.
This is needed to make a Windows 7 compatible builds.